### PR TITLE
Make print_tbl() defunct

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
 Collate: 
     'bind_inventories.R'
     'count_distinct.R'
+    'defunct.R'
     'ensure_distinct.R'
     'exact_join.R'
     'extract_lookup_table.R'
@@ -71,7 +72,6 @@ Collate:
     'patch.R'
     'pivot_table.R'
     'pivot_chart.R'
-    'print_tbl.R'
     'pull_distinct.R'
     'pull_first.R'
     'pull_summary.R'

--- a/R/defunct.R
+++ b/R/defunct.R
@@ -19,6 +19,8 @@ print_tbl <- function (
   ...
 ) {
 
+  .Defunct()
+
   require(pander)
   require(lubridate)
 


### PR DESCRIPTION
I don't think anything else is using `print_tbl()`, and if it is, it shouldn't be.