### PR TITLE
Remove deprecated tidyverse functions

### DIFF
--- a/R/defunct.R
+++ b/R/defunct.R
@@ -4,6 +4,7 @@
 #'  @importFrom dplyr group_by_ desc
 #'  @importForm stats median
 sort_by_ <- function (input_data, wt_var, group_var, wt_fun = median, na.rm = TRUE) {
+  .Defunct()
   grouped <- dplyr::group_by_(input_data, group_var)
   ranked <- mutate(grouped, .wt = apply(get(wt_var), 1, wt_fun, na.rm = na.rm))
   arrange(ranked, dplyr::desc(.wt))

--- a/R/defunct.R
+++ b/R/defunct.R
@@ -5,7 +5,7 @@
 #'  @importForm stats median
 sort_by_ <- function (input_data, wt_var, group_var, wt_fun = median, na.rm = TRUE) {
   .Defunct()
-  grouped <- dplyr::group_by_(input_data, group_var)
+  grouped <- dplyr::group_by_at(input_data, vars(group_var))
   ranked <- mutate(grouped, .wt = apply(get(wt_var), 1, wt_fun, na.rm = na.rm))
   arrange(ranked, dplyr::desc(.wt))
 }

--- a/R/extract_tree.R
+++ b/R/extract_tree.R
@@ -31,7 +31,7 @@ extract_tree <- function (input_data, form = "column_lineage", ...) {
   id_vars <- tidyselect::vars_select(names(input_data), matches("(src|cat)_id"))
 
   parts <- input_data %>%
-    select_(.dots = c(h_vars, id_vars)) %>%
+    select_at(vars(h_vars, id_vars)) %>%
     as.list() %>% lapply(as.character)
 
   root <- data_frame(parent = NA_character_, label = "Bay Area", uid = md5(""), depth = 1, round = 0)

--- a/R/pivot_table.R
+++ b/R/pivot_table.R
@@ -45,7 +45,6 @@ pivot_table <- function (
   year_var <- "year" # FIXME: don't hardcode!
 
   if (missing(columns)) {
-    # year_var <- "year" # WAS: first(names(input_data) %>% select_vars(ends_with("_yr")) %>% union("year"))
     columns <- year_var
     if ("pol_abbr" %in% names(input_data)) {
       columns <- c("pol_abbr", columns)

--- a/R/print_tbl.R
+++ b/R/print_tbl.R
@@ -63,7 +63,7 @@ print_tbl <- function (
   fmt_str <- . %>% format(na.encode = FALSE) %>% replace_which(is.na(.), "")
 
   if (isTRUE(column_totals)) {
-    column_totals <- input_data %>% select_(.dots = num_vars) %>% total_each()
+    column_totals <- input_data %>% select_at(vars(num_vars)) %>% total_each()
     preformatted <- bind_rows(input_data, column_totals)
   } else {
     preformatted <- input_data


### PR DESCRIPTION
I can find no more instances of `filter_()`, `arrange_()`, `select_()`, `group_by()`, `summarise()_`, or `summarize_()`. Am I missing anything? Issue #13 says "liberal use" but I found just a handful of instances in the first place. (?)