### PR TITLE
Update zzz.R to fix typo

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,5 +4,5 @@
   conflict_prefer("read_csv", "tbltools", "readr")
   conflict_prefer("write_csv", "tbltools", "readr")
   conflict_prefer("read_fst", "tbltools", "fst")
-  conflict_prefer("filter", "dplyer", "stats")
+  conflict_prefer("filter", "dplyr", "stats")
 }


### PR DESCRIPTION
Fix typo of `dplyer` to `dplyr`.