### PR TITLE
Add conflict rule for function `read_xls`

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,6 +4,6 @@
   conflict_prefer("read_csv", "tbltools", "readr")
   conflict_prefer("write_csv", "tbltools", "readr")
   conflict_prefer("read_fst", "tbltools", "fst")
-  conflict_prefer("readxl", "tbltools")
+  conflict_prefer("read_xls", "tbltools")
   conflict_prefer("filter", "dplyr", "stats")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,5 +4,6 @@
   conflict_prefer("read_csv", "tbltools", "readr")
   conflict_prefer("write_csv", "tbltools", "readr")
   conflict_prefer("read_fst", "tbltools", "fst")
+  conflict_prefer("readxl", "tbltools")
   conflict_prefer("filter", "dplyr", "stats")
 }


### PR DESCRIPTION
This function is present in both the tbltools and readxl packages.

I missed it before because the tidyverse package does not load the readxl package automatically.